### PR TITLE
fix: unmount elements on React effect cleanup

### DIFF
--- a/src/elements/useElement.ts
+++ b/src/elements/useElement.ts
@@ -76,12 +76,16 @@ const useElement = <
   const elementRef = useRef<Element | null>(null);
 
   useEffect(() => {
+    let active = true;
+    let mountedElement: Element | undefined;
+
     if (bt && wrapperRef.current && !elementRef.current) {
       const newElement = bt.createElement(
         type as never,
         options as never
       ) as unknown as Element; // conversion to unknown necessary because of different value prop types
 
+      mountedElement = newElement;
       elementRef.current = newElement;
 
       if (typeof ref === 'function') {
@@ -94,11 +98,33 @@ const useElement = <
       }
 
       (async () => {
-        await newElement.mount(`#${id}`).catch((mountError) => {
-          setLastOptions(() => {
-            throw mountError;
-          });
-        });
+        // deferring the mount lets an immediate cleanup (eg Strict Mode's
+        // effect replay) cancel it before the iframe is ever created
+        await Promise.resolve();
+
+        if (!active) {
+          return;
+        }
+
+        try {
+          await newElement.mount(`#${id}`);
+        } catch (mountError) {
+          if (active) {
+            setLastOptions(() => {
+              throw mountError;
+            });
+          }
+
+          return;
+        }
+
+        if (!active) {
+          if (newElement.mounted) {
+            newElement.unmount();
+          }
+
+          return;
+        }
 
         if (elementHasSetValueRef(newElement) && targetValueRef?.current) {
           newElement.setValueRef(targetValueRef.current);
@@ -107,6 +133,34 @@ const useElement = <
 
       setLastOptions(options);
     }
+
+    return () => {
+      active = false;
+
+      if (!mountedElement) {
+        return;
+      }
+
+      // unmount() throws if the element is not mounted, so gate on the
+      // public mounted flag; an in-flight mount that settles later is
+      // cleaned up by the !active check above
+      if (mountedElement.mounted) {
+        mountedElement.unmount();
+      }
+
+      if (elementRef.current === mountedElement) {
+        elementRef.current = null;
+      }
+
+      if (typeof ref === 'function') {
+        ref(null);
+      }
+
+      if (ref && typeof ref === 'object') {
+        // eslint-disable-next-line no-param-reassign
+        ref.current = null;
+      }
+    };
 
     // the only two dependencies that we need to watch for
     // are bt and wrapperRef. Anything else changing should not

--- a/test/elements/useElement.test.ts
+++ b/test/elements/useElement.test.ts
@@ -75,7 +75,7 @@ describe('useElement', () => {
     expect(result.current).toBeUndefined();
   });
 
-  test('should create and mount', () => {
+  test('should create and mount', async () => {
     const id = chance.string();
     const type = chance.pickone<ElementType>(['card', 'text']);
     const mockRef = { current: document.createElement('div') };
@@ -87,7 +87,7 @@ describe('useElement', () => {
 
     expect(bt.createElement).toHaveBeenCalledTimes(1);
     expect(bt.createElement).toHaveBeenCalledWith(type, {});
-    expect(mount).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
     expect(mount).toHaveBeenCalledWith(`#${id}`);
     expect(result.current).toBeDefined();
   });

--- a/test/elements/useElement.test.tsx
+++ b/test/elements/useElement.test.tsx
@@ -98,7 +98,7 @@ describe('useElement', () => {
     expect(result.current).toBeUndefined();
   });
 
-  test('should create and mount', () => {
+  test('should create and mount', async () => {
     const id = chance.string();
     const type = chance.pickone<ElementType>(['card', 'text']);
     const mockRef = { current: document.createElement('div') };
@@ -109,9 +109,129 @@ describe('useElement', () => {
 
     expect(bt.createElement).toHaveBeenCalledTimes(1);
     expect(bt.createElement).toHaveBeenCalledWith(type, {});
-    expect(mount).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
     expect(mount).toHaveBeenCalledWith(`#${id}`);
     expect(result.current).toBeDefined();
+  });
+
+  test('should unmount the element and clear the forwarded ref on cleanup', async () => {
+    const id = chance.string();
+    const type = chance.pickone<ElementType>(['card', 'text']);
+    const mockRef = { current: document.createElement('div') };
+    const objectRef = { current: null };
+
+    const { unmount: unmountHook } = renderHook(() =>
+      useElement(id, type, mockRef, {}, undefined, objectRef)
+    );
+
+    await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
+
+    const element = jest.mocked(bt.createElement).mock.results[0]
+      .value as unknown as { unmount: jest.Mock };
+
+    unmountHook();
+
+    expect(element.unmount).toHaveBeenCalledTimes(1);
+    expect(objectRef.current).toBeNull();
+  });
+
+  test('should not unmount an element whose mount never started', () => {
+    const element = { mount, update, mounted: false, unmount: jest.fn() };
+
+    jest.mocked(bt.createElement).mockReturnValue(element as never);
+
+    const mockRef = { current: document.createElement('div') };
+    const { unmount: unmountHook } = renderHook(() =>
+      useElement(chance.string(), 'card', mockRef, {})
+    );
+
+    unmountHook();
+
+    expect(mount).not.toHaveBeenCalled();
+    expect(element.unmount).not.toHaveBeenCalled();
+  });
+
+  test('should unmount an interrupted in-flight mount exactly once', async () => {
+    let resolveMount: () => void = () => undefined;
+    const pendingMount = new Promise<void>((resolve) => {
+      resolveMount = resolve;
+    });
+    const state = { mounted: false };
+    const element = {
+      get mounted() {
+        return state.mounted;
+      },
+      mount: jest.fn(() => {
+        state.mounted = true;
+        return pendingMount;
+      }),
+      unmount: jest.fn(() => {
+        state.mounted = false;
+      }),
+      update,
+    };
+
+    jest.mocked(bt.createElement).mockReturnValue(element as never);
+
+    const mockRef = { current: document.createElement('div') };
+    const { unmount: unmountHook } = renderHook(() =>
+      useElement(chance.string(), 'card', mockRef, {})
+    );
+
+    await waitFor(() => expect(element.mount).toHaveBeenCalledTimes(1));
+
+    unmountHook();
+
+    expect(element.unmount).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveMount());
+
+    expect(element.unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('should only mount the element kept by a Strict Mode effect replay', async () => {
+    const elements: Array<{
+      mounted: boolean;
+      mount: jest.Mock;
+      unmount: jest.Mock;
+    }> = [];
+
+    jest.mocked(bt.createElement).mockImplementation((() => {
+      const state = { mounted: false };
+      const element = {
+        get mounted() {
+          return state.mounted;
+        },
+        mount: jest.fn(() => {
+          state.mounted = true;
+          return Promise.resolve();
+        }),
+        unmount: jest.fn(() => {
+          state.mounted = false;
+        }),
+        update,
+      };
+
+      elements.push(element as never);
+
+      return element;
+    }) as never);
+
+    const mockRef = { current: document.createElement('div') };
+    const { unmount: unmountHook } = renderHook(
+      () => useElement(chance.string(), 'card', mockRef, {}),
+      { wrapper: React.StrictMode }
+    );
+
+    await waitFor(() => expect(elements).toHaveLength(2));
+
+    expect(elements[0].mount).not.toHaveBeenCalled();
+    expect(elements[0].unmount).not.toHaveBeenCalled();
+    await waitFor(() => expect(elements[1].mount).toHaveBeenCalledTimes(1));
+
+    unmountHook();
+
+    expect(elements[1].unmount).toHaveBeenCalledTimes(1);
   });
 
   test('should forward object ref to element on creation', async () => {


### PR DESCRIPTION
## Problem

`useElement` creates and mounts an element but never unmounts it, so when React removes the component (conditional render, route change, checkout form remount), the element leaks:

- The SDK still reports `mounted: true` and keeps its window listeners and iframe references.
- Any later call against the orphaned element (e.g. the `update()` this package fires whenever options change) **hangs forever** — the promise never settles — while postMessage traffic targets a frame that is no longer on `js.basistheory.com`. In consumer consoles this surfaces as:

  > Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://js.basistheory.com') does not match the recipient window's origin

We hit this in production (Whop checkout) with 2.12.2, and confirmed 2.15.0 has the same behavior. The hang/leak behavior above was reproduced against the live hosted client (`js.basistheory.com/web-elements/2.12.2/client/index.js`) by removing a mounted element's container without calling `unmount()` and then calling `update()`.

## Fix

The mount effect now returns a cleanup that unmounts the element and clears the forwarded ref. Two details verified against the hosted client's behavior:

- `unmount()` throws `"Element is not mounted."` when the element is not mounted, so every unmount call is gated on the public `mounted` flag. This also covers the interrupted in-flight mount: `mounted` flips true synchronously when `mount()` is called (the iframe is created eagerly), so cleanup can unmount mid-mount, and the post-`await` path won't double-unmount (observed: an interrupted mount's promise never settles, but the gate makes that path safe either way).
- The mount is deferred by one microtask so a Strict Mode effect replay cancels the throwaway first element before it ever creates an iframe — previously invisible because nothing was cleaned up at all.

## Tests

- Updated the two `should create and mount` tests for the deferred mount (assertion moves inside `waitFor`).
- Added coverage: unmount + ref clearing on cleanup, no unmount for a never-started mount, exactly one unmount for an interrupted in-flight mount, and Strict Mode replay mounting only the kept element.
- All 38 tests pass (`npx jest`, with the sibling `web-elements` checkout the jest config maps to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)